### PR TITLE
feature/eng-412-disable-borrow-button-if-no-liquidity

### DIFF
--- a/packages/app/src/features/my-portfolio/components/borrow-table/BorrowTable.tsx
+++ b/packages/app/src/features/my-portfolio/components/borrow-table/BorrowTable.tsx
@@ -73,7 +73,7 @@ export function BorrowTable({ assets, openDialog, eModeCategoryId }: BorrowTable
             },
             actions: {
               header: '',
-              renderCell: ({ token, debt, reserveStatus }) => {
+              renderCell: ({ token, debt, reserveStatus, available }) => {
                 return (
                   <ActionsCell>
                     <Button
@@ -82,7 +82,7 @@ export function BorrowTable({ assets, openDialog, eModeCategoryId }: BorrowTable
                       onClick={() => {
                         openDialog(borrowDialogConfig, { token })
                       }}
-                      disabled={reserveStatus === 'frozen'}
+                      disabled={reserveStatus === 'frozen' || available.isZero()}
                     >
                       Borrow
                     </Button>


### PR DESCRIPTION
Disable borrow button in table if liquidity is zero

<img width="1156" alt="Screenshot 2025-01-29 at 8 17 19 AM" src="https://github.com/user-attachments/assets/6a5c5e4f-8ab7-4e56-8660-42ec709752d3" />
