### PR TITLE
Disable refetch in modals

### DIFF
--- a/packages/app/src/config/consts.ts
+++ b/packages/app/src/config/consts.ts
@@ -11,6 +11,7 @@ export const NATIVE_ASSET_MOCK_ADDRESS = CheckedAddress('0xEeeeeEeeeEeEeeEeEeEee
 export const MAX_INT = BigInt(2 ** 256 - 1)
 
 export const QUERY_REFETCH_INTERVAL = 2000
+export const QUERY_STALE_TIME = 2000
 
 export const ZUSTAND_APP_STORE_LOCAL_STORAGE_KEY = 'zustand-app-store'
 export const ZUSTAND_APP_STORE_LOCAL_STORAGE_VERSION = 2

--- a/packages/app/src/domain/market-info/aave-data-layer/query.ts
+++ b/packages/app/src/domain/market-info/aave-data-layer/query.ts
@@ -21,9 +21,10 @@ import { calculateNetApy } from './calculateNetApy'
 export interface AaveDataLayerQueryKeyArgs {
   chainId: number
   account?: Address
+  refetchEnabled?: boolean
 }
-export function aaveDataLayerQueryKey({ chainId, account }: AaveDataLayerQueryKeyArgs): unknown[] {
-  return ['reserves', account, chainId]
+export function aaveDataLayerQueryKey({ chainId, account, refetchEnabled }: AaveDataLayerQueryKeyArgs): unknown[] {
+  return ['reserves', account, chainId, refetchEnabled ? 'refetch' : 'no-refetch']
 }
 export interface AaveDataLayerArgs extends AaveDataLayerQueryKeyArgs {
   wagmiConfig: Config
@@ -41,13 +42,13 @@ export type AaveUserSummaryReservesData = AaveUserSummary['userReservesData']
 export type AaveDataLayerQueryReturnType = Awaited<ReturnType<ReturnType<typeof aaveDataLayerQueryFn>>>
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function aaveDataLayer({ wagmiConfig, chainId, account, timeAdvance }: AaveDataLayerArgs) {
+export function aaveDataLayer({ wagmiConfig, chainId, account, timeAdvance, refetchEnabled }: AaveDataLayerArgs) {
   const uiPoolDataProvider = getContractAddress(uiPoolDataProviderAddress, chainId)
   const lendingPoolAddressProvider = getContractAddress(lendingPoolAddressProviderAddress, chainId)
   const uiIncentiveDataProvider = getContractAddress(uiIncentiveDataProviderAddress, chainId)
 
   return queryOptions({
-    queryKey: aaveDataLayerQueryKey({ chainId, account }),
+    queryKey: aaveDataLayerQueryKey({ chainId, account, refetchEnabled }),
     queryFn: aaveDataLayerQueryFn({
       uiPoolDataProvider,
       lendingPoolAddressProvider,

--- a/packages/app/src/domain/market-info/aave-data-layer/useAaveDataLayer.ts
+++ b/packages/app/src/domain/market-info/aave-data-layer/useAaveDataLayer.ts
@@ -6,15 +6,19 @@ import { SuspenseQueryWith } from '@/utils/types'
 import { useMemo } from 'react'
 import { AaveData, aaveDataLayer, aaveDataLayerSelectFn } from './query'
 import { useAccount } from '@/domain/hooks/useAccount'
-import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
+
 export interface UseAaveDataLayerParams {
   chainId: number
+  refetchInterval?: number
 }
 export type UseAaveDataLayerResultOnSuccess = SuspenseQueryWith<{
   aaveData: AaveData
 }>
 
-export function useAaveDataLayer({ chainId }: UseAaveDataLayerParams): UseAaveDataLayerResultOnSuccess {
+export function useAaveDataLayer({
+  chainId,
+  refetchInterval,
+}: UseAaveDataLayerParams): UseAaveDataLayerResultOnSuccess {
   const account = useAccount()
   const wagmiConfig = useConfig()
 
@@ -23,9 +27,10 @@ export function useAaveDataLayer({ chainId }: UseAaveDataLayerParams): UseAaveDa
       wagmiConfig,
       chainId,
       account,
+      refetchEnabled: !!refetchInterval,
     }),
     select: useMemo(() => aaveDataLayerSelectFn(), []),
-    refetchInterval: QUERY_REFETCH_INTERVAL,
+    refetchInterval,
   })
 
   return {

--- a/packages/app/src/domain/market-info/aave-data-layer/useAaveDataLayer.ts
+++ b/packages/app/src/domain/market-info/aave-data-layer/useAaveDataLayer.ts
@@ -6,7 +6,7 @@ import { SuspenseQueryWith } from '@/utils/types'
 import { useMemo } from 'react'
 import { AaveData, aaveDataLayer, aaveDataLayerSelectFn } from './query'
 import { useAccount } from '@/domain/hooks/useAccount'
-
+import { QUERY_STALE_TIME } from '@/config/consts'
 export interface UseAaveDataLayerParams {
   chainId: number
   refetchInterval?: number
@@ -31,6 +31,7 @@ export function useAaveDataLayer({
     }),
     select: useMemo(() => aaveDataLayerSelectFn(), []),
     refetchInterval,
+    staleTime: QUERY_STALE_TIME,
   })
 
   return {

--- a/packages/app/src/domain/market-info/useMarketInfo.ts
+++ b/packages/app/src/domain/market-info/useMarketInfo.ts
@@ -7,7 +7,7 @@ import { useMemo } from 'react'
 import { aaveDataLayer } from './aave-data-layer/query'
 import { MarketInfo, marketInfoSelectFn } from './marketInfo'
 import { useAccount } from '@/domain/hooks/useAccount'
-
+import { QUERY_STALE_TIME } from '@/config/consts'
 export interface UseMarketInfoParams {
   chainId: number
   timeAdvance?: number
@@ -34,6 +34,7 @@ export function useMarketInfo({
     }),
     select: useMemo(() => marketInfoSelectFn({ timeAdvance }), [timeAdvance]),
     refetchInterval,
+    staleTime: QUERY_STALE_TIME,
   })
 
   return {

--- a/packages/app/src/domain/market-info/useMarketInfo.ts
+++ b/packages/app/src/domain/market-info/useMarketInfo.ts
@@ -7,17 +7,21 @@ import { useMemo } from 'react'
 import { aaveDataLayer } from './aave-data-layer/query'
 import { MarketInfo, marketInfoSelectFn } from './marketInfo'
 import { useAccount } from '@/domain/hooks/useAccount'
-import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
 
 export interface UseMarketInfoParams {
   chainId: number
   timeAdvance?: number
+  refetchInterval?: number
 }
 export type UseMarketInfoResultOnSuccess = SuspenseQueryWith<{
   marketInfo: MarketInfo
 }>
 
-export function useMarketInfo({ chainId, timeAdvance }: UseMarketInfoParams): UseMarketInfoResultOnSuccess {
+export function useMarketInfo({
+  chainId,
+  timeAdvance,
+  refetchInterval,
+}: UseMarketInfoParams): UseMarketInfoResultOnSuccess {
   const account = useAccount()
   const wagmiConfig = useConfig()
 
@@ -26,9 +30,10 @@ export function useMarketInfo({ chainId, timeAdvance }: UseMarketInfoParams): Us
       wagmiConfig,
       chainId,
       account,
+      refetchEnabled: !!refetchInterval,
     }),
     select: useMemo(() => marketInfoSelectFn({ timeAdvance }), [timeAdvance]),
-    refetchInterval: QUERY_REFETCH_INTERVAL,
+    refetchInterval,
   })
 
   return {

--- a/packages/app/src/domain/wallet/useMarketWalletInfo.ts
+++ b/packages/app/src/domain/wallet/useMarketWalletInfo.ts
@@ -7,6 +7,7 @@ import { Token } from '../types/Token'
 import { TokenSymbol } from '../types/TokenSymbol'
 import { marketBalances } from './marketBalances'
 import { useAccount } from '@/domain/hooks/useAccount'
+import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
 
 export interface WalletBalance {
   balance: NormalizedUnitNumber
@@ -28,7 +29,7 @@ export interface MarketWalletInfo {
 export function useMarketWalletInfo({ chainId }: MarketWalletInfoParams): MarketWalletInfo {
   const account = useAccount()
   const wagmiConfig = useConfig()
-  const { marketInfo } = useMarketInfo({ chainId })
+  const { marketInfo } = useMarketInfo({ chainId, refetchInterval: QUERY_REFETCH_INTERVAL })
 
   const { data: balanceData } = useSuspenseQuery({
     ...marketBalances({

--- a/packages/app/src/features/actions/flavours/borrow/logic/borrowAction.ts
+++ b/packages/app/src/features/actions/flavours/borrow/logic/borrowAction.ts
@@ -41,6 +41,7 @@ export function createBorrowActionConfig(action: BorrowAction, context: ActionCo
     invalidates: () => [
       getBalancesQueryKeyPrefix({ chainId, account }),
       aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
       getBorrowAllowanceQueryKey({
         fromUser: account,
         toUser: wethGatewayAddress,

--- a/packages/app/src/features/actions/flavours/claim-market-rewards/logic/claimMarketRewardsAction.ts
+++ b/packages/app/src/features/actions/flavours/claim-market-rewards/logic/claimMarketRewardsAction.ts
@@ -21,6 +21,10 @@ export function createClaimMarketRewardsActionConfig(
       })
     },
 
-    invalidates: () => [aaveDataLayerQueryKey({ chainId, account }), getBalancesQueryKeyPrefix({ chainId, account })],
+    invalidates: () => [
+      aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
+      getBalancesQueryKeyPrefix({ chainId, account }),
+    ],
   }
 }

--- a/packages/app/src/features/actions/flavours/deposit/logic/depositAction.ts
+++ b/packages/app/src/features/actions/flavours/deposit/logic/depositAction.ts
@@ -63,6 +63,7 @@ export function createDepositActionConfig(action: DepositAction, context: Action
       allowanceQueryKey({ token: action.token.address, spender: lendingPool, account, chainId }),
       getBalancesQueryKeyPrefix({ chainId, account }),
       aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
     ],
   }
 }

--- a/packages/app/src/features/actions/flavours/repay/logic/repayAction.ts
+++ b/packages/app/src/features/actions/flavours/repay/logic/repayAction.ts
@@ -73,6 +73,7 @@ export function createRepayActionConfig(action: RepayAction, context: ActionCont
     invalidates: () => [
       getBalancesQueryKeyPrefix({ chainId, account }),
       aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
       allowanceQueryKey({ token: action.reserve.token.address, spender: lendingPool, account, chainId }),
     ],
   }

--- a/packages/app/src/features/actions/flavours/set-use-as-collateral/logic/setUseAsCollateralAction.ts
+++ b/packages/app/src/features/actions/flavours/set-use-as-collateral/logic/setUseAsCollateralAction.ts
@@ -23,6 +23,9 @@ export function createSetUseAsCollateralActionConfig(
       })
     },
 
-    invalidates: () => [aaveDataLayerQueryKey({ chainId, account })],
+    invalidates: () => [
+      aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
+    ],
   }
 }

--- a/packages/app/src/features/actions/flavours/set-user-e-mode/logic/setUserEModeAction.ts
+++ b/packages/app/src/features/actions/flavours/set-user-e-mode/logic/setUserEModeAction.ts
@@ -20,6 +20,9 @@ export function createSetUserEModeActionConfig(action: SetUserEModeAction, conte
       })
     },
 
-    invalidates: () => [aaveDataLayerQueryKey({ chainId, account })],
+    invalidates: () => [
+      aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
+    ],
   }
 }

--- a/packages/app/src/features/actions/flavours/withdraw/logic/withdrawAction.ts
+++ b/packages/app/src/features/actions/flavours/withdraw/logic/withdrawAction.ts
@@ -47,6 +47,7 @@ export function createWithdrawActionConfig(action: WithdrawAction, context: Acti
       allowanceQueryKey({ token: aTokenAddress, spender: wethGatewayAddress, account, chainId }),
       getBalancesQueryKeyPrefix({ chainId, account }),
       aaveDataLayerQueryKey({ chainId, account }),
+      aaveDataLayerQueryKey({ chainId, account, refetchEnabled: true }),
     ],
   }
 }

--- a/packages/app/src/features/market-details/logic/useMarketDetails.ts
+++ b/packages/app/src/features/market-details/logic/useMarketDetails.ts
@@ -18,6 +18,7 @@ import { MarketOverview, WalletOverview } from '../types'
 import { makeMarketOverview } from './makeMarketOverview'
 import { makeWalletOverview } from './makeWalletOverview'
 import { useMarketDetailsParams } from './useMarketDetailsParams'
+import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
 
 export interface UseMarketDetailsResult {
   token: Token
@@ -35,7 +36,7 @@ export function useMarketDetails(): UseMarketDetailsResult {
   const params = useMarketDetailsParams()
   const { chainId, asset } = params
 
-  const { marketInfo } = useMarketInfo({ chainId })
+  const { marketInfo } = useMarketInfo({ chainId, refetchInterval: QUERY_REFETCH_INTERVAL })
   // const { D3MInfo } = useD3MInfo({ chainId })
   const walletInfo = useMarketWalletInfo({ chainId })
   const { meta: chainMeta } = getChainConfigEntry(chainId)

--- a/packages/app/src/features/markets/logic/useMarkets.ts
+++ b/packages/app/src/features/markets/logic/useMarkets.ts
@@ -6,7 +6,7 @@ import { usePageChainId } from '@/domain/hooks/usePageChainId'
 import { MarketEntry } from '../types'
 import { MarketStats, aggregateStats } from './aggregate-stats'
 import { transformReserves } from './transformers'
-
+import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
 export interface UseMarketsResults {
   marketStats: MarketStats
   chainName: string
@@ -17,7 +17,7 @@ export interface UseMarketsResults {
 
 export function useMarkets(): UseMarketsResults {
   const { chainId } = usePageChainId()
-  const { marketInfo } = useMarketInfo({ chainId })
+  const { marketInfo } = useMarketInfo({ chainId, refetchInterval: QUERY_REFETCH_INTERVAL })
   // const { D3MInfo } = useD3MInfo({ chainId })
   const { meta: chainMeta } = getChainConfigEntry(chainId)
 

--- a/packages/app/src/features/my-portfolio/logic/useMyPortfolio.ts
+++ b/packages/app/src/features/my-portfolio/logic/useMyPortfolio.ts
@@ -13,7 +13,7 @@ import { makePositionSummary } from './position'
 import { PositionSummary } from './types'
 import { WalletCompositionInfo, makeWalletComposition } from './wallet-composition'
 import { NetApyDetails } from '@/domain/market-info/aave-data-layer/calculateNetApy'
-
+import { QUERY_REFETCH_INTERVAL } from '@/config/consts'
 export interface UseMyPortfolioResults {
   positionSummary: PositionSummary
   deposits: Deposit[]
@@ -28,7 +28,7 @@ export interface UseMyPortfolioResults {
 
 export function useMyPortfolio(): UseMyPortfolioResults {
   const { chainId } = usePageChainId()
-  const { marketInfo } = useMarketInfo({ chainId })
+  const { marketInfo } = useMarketInfo({ chainId, refetchInterval: QUERY_REFETCH_INTERVAL })
   const walletInfo = useMarketWalletInfo({ chainId })
   const [compositionWithDeposits, setCompositionWithDeposits] = useState(true)
   const nativeAssetInfo = getNativeAssetInfo(marketInfo.chainId)


### PR DESCRIPTION
**Initial Issue**

The max repay value was being recalculated every two seconds due to the refetch interval. This value was used as the key for the `ActionsContainer` component, causing a remount and then a contract simulation every interval.

**The Changes**

Makes the refetch interval opt-in and uses different keys for stable vs refetch-enabled queries.
The queries for the modals should refetch on mount if outside of the stale time.
The queries for the pages update every two seconds.